### PR TITLE
Installation fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setuptools.setup(
         "pandas",
         "matplotlib",
         "scipy",
-        "tkinter",
         "pylab"
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,13 @@ setuptools.setup(
     url='https://github.com/AndreMacedo88/VEnCode',
     packages=setuptools.find_packages(),
     install_requires=[
+        "biopython",
         "tqdm",
         "numpy",
         "pandas",
         "matplotlib",
         "scipy",
+        "pyvisa",
         "pylab"
     ],
     classifiers=[


### PR DESCRIPTION
Hi everyone,

`tkinter` isn't actually a package on pypi AFAIK, and comes with most python installations or needs to be installed externally. I removed it from `setup.py`.

Also, `pylab` needs `pyvisa` to be installed, and wasn't doing a good job handling the dependency on it's own, so I explicitly added it. Finally, I couldn't import the module without also having `biopython` installed, so I added that as a dependency. Thanks for the really nice tool!